### PR TITLE
Added EU fund image to comply with financing rules

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -1,4 +1,4 @@
-![European Regional Development Fund](https://github.com/e-gov/RIHA-Frontend/raw/master/logo/EU/EU.png "European Regional Development Fund - DO NOT REMOVE THIS IMAGE BEFORE 01.06.2022")
+![European Regional Development Fund](img/EU.png "European Regional Development Fund - DO NOT REMOVE THIS IMAGE BEFORE 01.06.2022")
 
 # X-Road Components
 

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -1,3 +1,5 @@
+![European Regional Development Fund](https://github.com/e-gov/RIHA-Frontend/raw/master/logo/EU/EU.png "European Regional Development Fund - DO NOT REMOVE THIS IMAGE BEFORE 01.06.2022")
+
 # X-Road Components
 
 This page contains a list of reusable X-Road components implemented by the


### PR DESCRIPTION
As I understand the original list (https://github.com/jointxroad/components) will be closed in near future. Therefore the logo is needed, because the original list was compiled using EU funds (through subcontracting by Estonian Information System Authority). The image is needed to be in place until 01.06.2022